### PR TITLE
Set full-page background

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,29 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;600;900&display=swap" rel="stylesheet">
-  <style>
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-    html { scroll-behavior: smooth; }
-    body { font-family:'Poppins',sans-serif; color: #fff; background: #000; padding-top: 80px; }
-    header {position: fixed; top: 0; width: 100%; display: flex; justify-content: space-between; align-items: center; padding: 20px 50px; background: rgba(0,0,0,0.7); z-index: 100;}
-    header .logo { font-weight: 900; font-size: 20px; }
-    header nav a { margin: 0 20px; text-decoration: none; color: #fff; font-weight: 600; transition: color 0.3s; }
-    header nav a.active { color: #e63946; }
-    header a:hover { color:#e63946; }
-    section { padding: 100px 50px; }
-    .intro { display: flex; align-items: center; justify-content: space-between; height: 100vh; padding-top: 80px; }
-    .intro-left { max-width: 60%; }
-    .intro-left .small { color: #e63946; font-size: 18px; font-weight: 800; }
-    .intro-left h1 { font-size: 50px; font-weight: 900; margin: 10px 0; }
-    .intro-left .title { color: #e63946; font-size: 18px; font-weight: 800; margin-bottom: 20px; }
-    .intro-left p { font-weight: 300; line-height: 1.5; margin-bottom: 30px; }
-    .intro-left .btn { display: inline-block; border: 1px solid #e63946; padding: 12px 30px; text-decoration: none; font-weight: 800; }
-    .intro-right img { max-height: 80vh; border-radius: 10px; }
-    .quote { text-align: center; font-style: italic; font-weight: 300; font-size: 20px; color: #ccc; margin-top: -40px; }
-    .section-title { font-size: 32px; font-weight: 600; color: #e63946; margin-bottom: 20px; }
-    .content { max-width: 800px; margin: 0 auto; font-weight: 300; line-height: 1.6; margin-bottom: 20px; }
-    .btn-more { display: inline-block; margin-top: 15px; border: 1px solid #e63946; padding: 8px 20px; text-decoration: none; font-weight: 600; color: #e63946; font-size: 14px; }
-  </style>
+  <link rel="stylesheet" href="style.css">
 </head>
 
 <body>

--- a/portfolio.html
+++ b/portfolio.html
@@ -5,28 +5,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Victor Lande — Detailed Portfolio</title>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;600;900&display=swap" rel="stylesheet">
-  <style>
-    * { margin:0; padding:0; box-sizing:border-box; }
-    body { font-family:'Poppins',sans-serif; background:#000; color:#fff; padding-top:80px; }
-    header { position:fixed; top:0; width:100%; display:flex; justify-content:center; background:rgba(0,0,0,0.7); padding: 20px 50px; z-index:100; }
-    header a { margin:0 20px; color:#fff; text-decoration:none; font-weight:600; }
-    header a:hover { color:#e63946; }
-    header a.active { color:#e63946; }
-    section { padding:80px 50px; max-width:900px; margin:0 auto; }
-    h1,h2 { font-weight:900; }
-    h1 { font-size:48px; color:#e63946; margin-bottom:40px; text-align:center; }
-    h2 { font-size:32px; margin-bottom:20px; }
-    .item { margin-bottom:20px; }
-    .item h3 { font-size:24px; font-weight:600; margin-bottom:5px;color:#e63946;  }
-    .item p { font-weight:300; line-height:1.6; }
-  </style>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <header>
-    <a href="index.html">Home</a>
-    <a href="portfolio.html#career" class="active">Career</a>
-    <a href="portfolio.html#education">Education</a>
-    <a href="portfolio.html#engagement">Engagement</a>
+    <div class="logo">Portfolio</div>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="portfolio.html#career" class="active">Career</a>
+      <a href="portfolio.html#education">Education</a>
+      <a href="portfolio.html#engagement">Engagement</a>
+    </nav>
   </header>
 
   <h1>Portfolio</h1>

--- a/style.css
+++ b/style.css
@@ -10,7 +10,9 @@ html {
 body {
   font-family: 'Poppins', sans-serif;
   color: #fff;
-  background: #000;
+  background: url('ChatGPT Image Jul 30, 2025, 03_08_24 PM.png')
+    no-repeat center center fixed;
+  background-size: cover;
   padding-top: 80px;
 }
 
@@ -44,7 +46,9 @@ header nav a:hover {
 
 /* Sections */
 section {
-  padding: 100px 50px;
+  padding: 80px 50px;
+  max-width: 900px;
+  margin: 0 auto;
 }
 
 /* Intro (index.html) */
@@ -137,9 +141,4 @@ section {
   color: #e63946;
   text-align: center;
   margin: 40px 0;
-}
-section {
-  padding: 80px 50px;
-  max-width: 900px;
-  margin: 0 auto;
 }


### PR DESCRIPTION
## Summary
- use a common stylesheet for both HTML files
- move page styling to `style.css`
- unify header markup across pages

## Testing
- `python -m py_compile feed.py`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_688a1f6bf5bc832c808aecab014bd860