### PR TITLE
fix: correct per-item images and trim XML parsing

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -71,18 +71,17 @@ fetch('portfolio.xml')
   .then(res => res.text())
   .then(str => new DOMParser().parseFromString(str,'text/xml'))
   .then(xml => {
+    const getText = (n, s) => (n.querySelector(s)?.textContent || '').trim();
     xml.querySelectorAll('item').forEach(item => {
-      const cat   = item.querySelector('category').textContent;
-      const title = item.querySelector('title').textContent;
-      const date  = item.querySelector('date').textContent;
-      const short = item.querySelector('short').textContent;
-      const long  = item.querySelector('long').textContent;
-      const link  = item.querySelector('link').textContent;
+      const cat   = getText(item, 'category');
+      const title = getText(item, 'title');
+      const date  = getText(item, 'date');
+      const short = getText(item, 'short');
+      const long  = getText(item, 'long');
+      const link  = getText(item, 'link');
+      const image = getText(item, 'image');
 
-      const imgNode = item.querySelector('image');
-      const image = imgNode ? imgNode.textContent : '';
-
-      container = document.getElementById(`feed-${cat}-long`);
+      const container = document.getElementById(`feed-${cat}-long`);
       if (container) {
         const div = document.createElement('div');
         div.className = 'item';

--- a/portfolio.xml
+++ b/portfolio.xml
@@ -1,36 +1,55 @@
 <?xml version='1.0' encoding='utf-8'?>
-<rss version="2.0"><channel><title>"Victor-José's Online Portfolio"
-</title><link>https://VICTORJOSEARAVENALANDE.github.io/onlineportfolio-test
-</link><description>All new certificates, jobs, projects and milestones.
-</description><language>en-US</language><image>https://VICTORJOSEARAVENALANDE.github.io/onlineportfolio-test
-
-/images/CanlabImage.png</image><item><title>Leading Research Technician, CANlab
-</title><link>https://www.sv.uio.no/psi/english/research/groups/canlab/index.html
-</link><short>part-time work in the The Cognitive and Affective Neuroscience Lab.
-</short><long>Promoted to the position as a Leading Research Technician for The Cognitive and Affective Neuroscience Lab (CANlab) at the University of Oslo (UiO).
-</long><date>Sun, 01 Jun 2025 00:00:00 GMT
-</date><category>career</category><image>https://VICTORJOSEARAVENALANDE.github.io/onlineportfolio-test
-/images/placeholder.png</image></item><item><title>MSc Cognitive Neuroscience (grade A)
-</title><link>https://www.uio.no/english/studies/programmes/psychology-master/programme-options/cogneuro/learning-outcomes/
-</link><short>Research degree with focus on programming, analysing and visualising brain metrics through tools like EEG and (f)MRI. Additional PHD-module in machine learning and a master thesis titled: New Insights into Adolescent 15q11.2 CNVs: A Dual Approach Using Normative Modelling and Raw Metrics.
-</short><long>Master program in Psychology at the University of Oslo. I recieved three grades C (5 ETC module), B(5 ETC module) and A (60 ETC thesis). In total I graduated with 125 ETCs, where an extra 5 ETCs came from the additional PHD-module I attended outside of my own curriculum.
-</long><date>2023-2025
-</date><category>education</category><image>https://VICTORJOSEARAVENALANDE.github.io/onlineportfolio-test
-/images/certificate_roehampton.jpg</image></item><item><title>Psychology BSc (First-Class Honors Degree 1:1)
-</title><link>https://www.roehampton.ac.uk/study/undergraduate-courses/psychology/
-</link><short>Dissertation titled: Mental Time Travel and False Memory
-</short><long>This suite of Psychology programmes has a strong history of accreditation and has consistently been commended for the high-quality education and outstanding student experience by the British Psychological Society (BPS). List of Modules: - Introduction to Research Methods in Psychology - Psychological Problem Solving - Mind, Body &amp; Brain (1 &amp; 2) - Research Methods and Statistics (1 &amp; 2) - Social and Developmental Psychology (1 &amp; 2) - Psychology in the Real World - Understanding Mental Health - Perspectives on Consciousness (Single Honours Psychology only) - Individual Differences and Psychometric Research - Neuropsychology - Cognition and Emotion - Health Psychology - Topics in Adult Psychopathology - Extended Research Project
-</long><date>2020-2023
-</date><category>education</category><image>https://VICTORJOSEARAVENALANDE.github.io/onlineportfolio-test
-/images/placeholder.png</image></item><item><title>Career Essentials in GitHub Professional Certificate
-</title><link>https://VICTORJOSEARAVENALANDE.github.io/onlineportfolio-test
-</link><short>Certificate provided by LinkedIn and Github.
-</short><long>Certificate proving a fundamental competence in Github for professional use, provided by Github and LinkedIn.
-</long><date>Mon, 14 Jul 2025 00:00:00 GMT
-</date><category>engagement</category></item><item><title>The Online Portfolio
-</title><link>https://victorjosearavenalande.github.io/onlineportfolio-test/
-</link><short>Launched my personal online porfolio
-</short><long>During my hunt for work, I decided that I did not want to lose my momentum from my intense graduate program. One skill to enhance was GIthub, and somehow I ended up making my own webpage for my portfolio.
-</long><date>Mon, 14 Jul 2025 00:00:00 GMT
-</date><category>engagement</category><image>https://VICTORJOSEARAVENALANDE.github.io/onlineportfolio-test
-/images/placeholder.png</image></item></channel></rss>
+<rss version="2.0">
+  <channel>
+    <title>"Victor-José's Online Portfolio"</title>
+    <link>https://VICTORJOSEARAVENALANDE.github.io/onlineportfolio-test</link>
+    <description>All new certificates, jobs, projects and milestones.</description>
+    <language>en-US</language>
+    <image>https://VICTORJOSEARAVENALANDE.github.io/onlineportfolio-test/images/CanlabImage.png</image>
+    <item>
+      <title>Leading Research Technician, CANlab</title>
+      <link>https://www.sv.uio.no/psi/english/research/groups/canlab/index.html</link>
+      <short>part-time work in the The Cognitive and Affective Neuroscience Lab.</short>
+      <long>Promoted to the position as a Leading Research Technician for The Cognitive and Affective Neuroscience Lab (CANlab) at the University of Oslo (UiO).</long>
+      <date>Sun, 01 Jun 2025 00:00:00 GMT</date>
+      <category>career</category>
+      <image>https://VICTORJOSEARAVENALANDE.github.io/onlineportfolio-test/images/placeholder.png</image>
+    </item>
+    <item>
+      <title>MSc Cognitive Neuroscience (grade A)</title>
+      <link>https://www.uio.no/english/studies/programmes/psychology-master/programme-options/cogneuro/learning-outcomes/</link>
+      <short>Research degree with focus on programming, analysing and visualising brain metrics through tools like EEG and (f)MRI. Additional PHD-module in machine learning and a master thesis titled: New Insights into Adolescent 15q11.2 CNVs: A Dual Approach Using Normative Modelling and Raw Metrics.</short>
+      <long>Master program in Psychology at the University of Oslo. I recieved three grades C (5 ETC module), B(5 ETC module) and A (60 ETC thesis). In total I graduated with 125 ETCs, where an extra 5 ETCs came from the additional PHD-module I attended outside of my own curriculum.</long>
+      <date>2023-2025</date>
+      <category>education</category>
+      <image>https://VICTORJOSEARAVENALANDE.github.io/onlineportfolio-test/images/CanlabImage.png</image>
+    </item>
+    <item>
+      <title>Psychology BSc (First-Class Honors Degree 1:1)</title>
+      <link>https://www.roehampton.ac.uk/study/undergraduate-courses/psychology/</link>
+      <short>Dissertation titled: Mental Time Travel and False Memory</short>
+      <long>This suite of Psychology programmes has a strong history of accreditation and has consistently been commended for the high-quality education and outstanding student experience by the British Psychological Society (BPS). List of Modules: - Introduction to Research Methods in Psychology - Psychological Problem Solving - Mind, Body &amp; Brain (1 &amp; 2) - Research Methods and Statistics (1 &amp; 2) - Social and Developmental Psychology (1 &amp; 2) - Psychology in the Real World - Understanding Mental Health - Perspectives on Consciousness (Single Honours Psychology only) - Individual Differences and Psychometric Research - Neuropsychology - Cognition and Emotion - Health Psychology - Topics in Adult Psychopathology - Extended Research Project</long>
+      <date>2020-2023</date>
+      <category>education</category>
+      <image>https://VICTORJOSEARAVENALANDE.github.io/onlineportfolio-test/images/certificate_roehampton.jpg</image>
+    </item>
+    <item>
+      <title>Career Essentials in GitHub Professional Certificate</title>
+      <link>https://VICTORJOSEARAVENALANDE.github.io/onlineportfolio-test</link>
+      <short>Certificate provided by LinkedIn and Github.</short>
+      <long>Certificate proving a fundamental competence in Github for professional use, provided by Github and LinkedIn.</long>
+      <date>Mon, 14 Jul 2025 00:00:00 GMT</date>
+      <category>engagement</category>
+      <image>https://VICTORJOSEARAVENALANDE.github.io/onlineportfolio-test/images/placeholder.png</image>
+    </item>
+    <item>
+      <title>The Online Portfolio</title>
+      <link>https://victorjosearavenalande.github.io/onlineportfolio-test/</link>
+      <short>Launched my personal online porfolio</short>
+      <long>During my hunt for work, I decided that I did not want to lose my momentum from my intense graduate program. One skill to enhance was GIthub, and somehow I ended up making my own webpage for my portfolio.</long>
+      <date>Mon, 14 Jul 2025 00:00:00 GMT</date>
+      <category>engagement</category>
+      <image>https://VICTORJOSEARAVENALANDE.github.io/onlineportfolio-test/images/placeholder.png</image>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
## Summary
- add missing image entries to portfolio RSS items
- trim whitespace when parsing XML to avoid broken image URLs

## Testing
- `python -m py_compile feed.py`


------
https://chatgpt.com/codex/tasks/task_e_689f46ab30dc832cade09e67ab2476f2