### PR TITLE
Render portfolio items with title-first layout

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -85,12 +85,11 @@ fetch('portfolio.xml')
       if (container) {
         const div = document.createElement('div');
         div.className = 'item';
-        let html = '';
+        let html = `<h3>${title}</h3>`;
         if (image) {
           html += `<img src="${image}" alt="${title}" class="item-image">`;
         }
         html += `
-          <h3>${title}</h3>
           <small>${date}</small>
           <p>${long}</p>
         `;


### PR DESCRIPTION
## Summary
- Ensure portfolio item HTML renders in the order: title, optional image, date, and long description

## Testing
- `python -m py_compile feed.py`
- Manual Python check of generated HTML order

------
https://chatgpt.com/codex/tasks/task_e_68a476a1b184832c96a5963636013e09